### PR TITLE
Enable trunk in edenai

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,8 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/configs/.isort.cfg
+++ b/.trunk/configs/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,10 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,5 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "D4", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]

--- a/.trunk/configs/svgo.config.js
+++ b/.trunk/configs/svgo.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  plugins: [
+    {
+      name: "preset-default",
+      params: {
+        overrides: {
+          removeViewBox: false, // https://github.com/svg/svgo/issues/1128
+          sortAttrs: true,
+          removeOffCanvasPaths: true,
+        },
+      },
+    },
+  ],
+};

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,37 @@
+version: 0.1
+cli:
+  version: 1.15.0
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.2.3
+      uri: https://github.com/trunk-io/plugins
+runtimes:
+  enabled:
+    - node@18.12.1
+    - python@3.10.8
+lint:
+  enabled:
+    - actionlint@1.6.25
+    - bandit@1.7.5
+    - black@23.9.1
+    - checkov@2.4.9
+    - git-diff-check
+    - isort@5.12.0
+    - markdownlint@0.36.0
+    - osv-scanner@1.3.6
+    - oxipng@8.0.0
+    - prettier@3.0.3
+    - pylint@2.17.5
+    - ruff@0.0.288
+    - svgo@3.0.2
+    - taplo@0.8.1
+    - trivy@0.45.0
+    - trufflehog@3.55.1
+    - yamllint@1.32.0
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available


### PR DESCRIPTION
Integrates trunk check as a metalinter for edenai-api. To see results yourself 

```
curl https://get.trunk.io -fsSL | bash
trunk check --sample=5
```

Looks like a bunch of code can be fixed up easily.. try...
trunk fmt --all
trunk check -y # (for autofixes)
