### PR TITLE
Feat/catch validation errors

### DIFF
--- a/edenai_apis/features/audio/speech_to_text_async/speech_to_text_async_dataclass.py
+++ b/edenai_apis/features/audio/speech_to_text_async/speech_to_text_async_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence, Optional
 
 from pydantic import BaseModel, StrictStr, Field
 
 
-class SpeechDiarizationEntry(BaseModel):
+class SpeechDiarizationEntry(NoRaiseBaseModel):
     segment: StrictStr
     start_time: Optional[StrictStr]
     end_time: Optional[StrictStr]
@@ -11,12 +12,12 @@ class SpeechDiarizationEntry(BaseModel):
     confidence: Optional[float]
 
 
-class SpeechDiarization(BaseModel):
+class SpeechDiarization(NoRaiseBaseModel):
     total_speakers: int
     entries: Sequence[SpeechDiarizationEntry] = Field(default_factory=list)
     error_message: Optional[str] = None
 
 
-class SpeechToTextAsyncDataClass(BaseModel):
+class SpeechToTextAsyncDataClass(NoRaiseBaseModel):
     text: StrictStr
     diarization: SpeechDiarization

--- a/edenai_apis/features/audio/text_to_speech/text_to_speech_dataclass.py
+++ b/edenai_apis/features/audio/text_to_speech/text_to_speech_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class TextToSpeechDataClass(BaseModel):
+class TextToSpeechDataClass(NoRaiseBaseModel):
     audio: StrictStr
     voice_type: int
     audio_resource_url: StrictStr

--- a/edenai_apis/features/audio/text_to_speech_async/text_to_speech_async_dataclass.py
+++ b/edenai_apis/features/audio/text_to_speech_async/text_to_speech_async_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class TextToSpeechAsyncDataClass(BaseModel):
+class TextToSpeechAsyncDataClass(NoRaiseBaseModel):
     audio: StrictStr
     voice_type: int
     audio_resource_url: StrictStr

--- a/edenai_apis/features/image/anonymization/anonymization_dataclass.py
+++ b/edenai_apis/features/image/anonymization/anonymization_dataclass.py
@@ -1,22 +1,23 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence, Optional
 
 from pydantic import BaseModel, StrictStr, Field
 
 
-class AnonymizationBoundingBox(BaseModel):
+class AnonymizationBoundingBox(NoRaiseBaseModel):
     x_min: Optional[float]
     x_max: Optional[float]
     y_min: Optional[float]
     y_max: Optional[float]
 
 
-class AnonymizationItem(BaseModel):
+class AnonymizationItem(NoRaiseBaseModel):
     kind: StrictStr
     confidence: float
     bounding_boxes: AnonymizationBoundingBox
 
 
-class AnonymizationDataClass(BaseModel):
+class AnonymizationDataClass(NoRaiseBaseModel):
     image: StrictStr
     image_resource_url: StrictStr
     items: Sequence[AnonymizationItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/background_removal/background_removal_dataclass.py
+++ b/edenai_apis/features/image/background_removal/background_removal_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 import base64
 import importlib
 import uuid
@@ -9,7 +10,7 @@ from pydantic import BaseModel, Field
 # from edenai_apis.utils.upload_s3 import upload_file_bytes_to_s3, USER_PROCESS
 
 
-class BackgroundRemovalDataClass(BaseModel):
+class BackgroundRemovalDataClass(NoRaiseBaseModel):
     """
     The response of the background removal API.
 

--- a/edenai_apis/features/image/embeddings/embeddings_dataclass.py
+++ b/edenai_apis/features/image/embeddings/embeddings_dataclass.py
@@ -1,11 +1,12 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field
 
 
-class EmbeddingDataClass(BaseModel):
+class EmbeddingDataClass(NoRaiseBaseModel):
     embedding: Sequence[float]
 
 
-class EmbeddingsDataClass(BaseModel):
+class EmbeddingsDataClass(NoRaiseBaseModel):
     items: Sequence[EmbeddingDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/image/explicit_content/explicit_content_dataclass.py
+++ b/edenai_apis/features/image/explicit_content/explicit_content_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence, Union
 
 from pydantic import (
@@ -36,7 +37,7 @@ SubCategoryType = Union[
 ]
 
 
-class ExplicitItem(BaseModel):
+class ExplicitItem(NoRaiseBaseModel):
     label: StrictStr
     likelihood: int
     likelihood_score: float
@@ -50,7 +51,7 @@ class ExplicitItem(BaseModel):
         return value.value
 
 
-class ExplicitContentDataClass(BaseModel):
+class ExplicitContentDataClass(NoRaiseBaseModel):
     nsfw_likelihood: int
     nsfw_likelihood_score: float
     items: Sequence[ExplicitItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/face_compare/face_compare_dataclass.py
+++ b/edenai_apis/features/image/face_compare/face_compare_dataclass.py
@@ -1,19 +1,20 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field
 
 
-class FaceCompareBoundingBox(BaseModel):
+class FaceCompareBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class FaceMatch(BaseModel):
+class FaceMatch(NoRaiseBaseModel):
     confidence: Optional[float]
     bounding_box: FaceCompareBoundingBox
 
 
-class FaceCompareDataClass(BaseModel):
+class FaceCompareDataClass(NoRaiseBaseModel):
     items: Sequence[FaceMatch] = Field(default_factory=list)

--- a/edenai_apis/features/image/face_detection/face_detection_dataclass.py
+++ b/edenai_apis/features/image/face_detection/face_detection_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class FaceLandmarks(BaseModel):
+class FaceLandmarks(NoRaiseBaseModel):
     left_eye: Sequence[float] = Field(default_factory=list)
     left_eye_top: Sequence[float] = Field(default_factory=list)
     left_eye_right: Sequence[float] = Field(default_factory=list)
@@ -58,7 +59,7 @@ class FaceLandmarks(BaseModel):
     right_cheek_center: Sequence[float] = Field(default_factory=list)
 
 
-class FaceEmotions(BaseModel):
+class FaceEmotions(NoRaiseBaseModel):
     joy: Optional[int]  # all
     sorrow: Optional[int]  # all
     anger: Optional[int]  # all
@@ -88,12 +89,12 @@ class FaceEmotions(BaseModel):
         )
 
 
-class FaceHairColor(BaseModel):
+class FaceHairColor(NoRaiseBaseModel):
     color: StrictStr
     confidence: float
 
 
-class FaceHair(BaseModel):
+class FaceHair(NoRaiseBaseModel):
     hair_color: Sequence[FaceHairColor] = Field(default_factory=list)  # microsoft
     bald: Optional[float]  # microsoft
     invisible: Optional[bool]  # microsoft
@@ -103,7 +104,7 @@ class FaceHair(BaseModel):
         return FaceHair(hair_color=[], bald=None, invisible=None)
 
 
-class FaceFacialHair(BaseModel):
+class FaceFacialHair(NoRaiseBaseModel):
     moustache: Optional[float]  # microsoft, amazon
     beard: Optional[float]  # microsoft, amazon
     sideburns: Optional[float]  # microsoft
@@ -113,7 +114,7 @@ class FaceFacialHair(BaseModel):
         return FaceFacialHair(moustache=None, beard=None, sideburns=None)
 
 
-class FaceBoundingBox(BaseModel):
+class FaceBoundingBox(NoRaiseBaseModel):
     x_min: Optional[float]
     x_max: Optional[float]
     y_min: Optional[float]
@@ -129,7 +130,7 @@ class FaceBoundingBox(BaseModel):
         )
 
 
-class FacePoses(BaseModel):
+class FacePoses(NoRaiseBaseModel):
     pitch: Optional[float]  # all
     roll: Optional[float]  # all
     yaw: Optional[float]  # all
@@ -139,7 +140,7 @@ class FacePoses(BaseModel):
         return FacePoses(pitch=None, roll=None, yaw=None)
 
 
-class FaceQuality(BaseModel):
+class FaceQuality(NoRaiseBaseModel):
     noise: Optional[float]  # microsoft
     exposure: Optional[float]  # microsoft
     blur: Optional[float]  # microsoft
@@ -157,7 +158,7 @@ class FaceQuality(BaseModel):
         )
 
 
-class FaceMakeup(BaseModel):
+class FaceMakeup(NoRaiseBaseModel):
     eye_make: Optional[bool]  # microsoft
     lip_make: Optional[bool]  # microsoft
 
@@ -166,7 +167,7 @@ class FaceMakeup(BaseModel):
         return FaceMakeup(eye_make=None, lip_make=None)
 
 
-class FaceFeatures(BaseModel):
+class FaceFeatures(NoRaiseBaseModel):
     eyes_open: Optional[float]  # amazon
     smile: Optional[float]  # amazon
     mouth_open: Optional[float]  # amazon
@@ -176,7 +177,7 @@ class FaceFeatures(BaseModel):
         return FaceFeatures(eyes_open=None, smile=None, mouth_open=None)
 
 
-class FaceAccessories(BaseModel):
+class FaceAccessories(NoRaiseBaseModel):
     sunglasses: Optional[float]  # microsoft, amazon
     reading_glasses: Optional[float]  # microsoft
     swimming_goggles: Optional[float]  # microsoft
@@ -196,7 +197,7 @@ class FaceAccessories(BaseModel):
         )
 
 
-class FaceOcclusions(BaseModel):
+class FaceOcclusions(NoRaiseBaseModel):
     eye_occluded: Optional[bool]  # microsoft
     forehead_occluded: Optional[bool]  # microsoft
     mouth_occluded: Optional[bool]  # microsoft
@@ -210,7 +211,7 @@ class FaceOcclusions(BaseModel):
         )
 
 
-class FaceItem(BaseModel):
+class FaceItem(NoRaiseBaseModel):
     confidence: float
     landmarks: FaceLandmarks
     emotions: FaceEmotions
@@ -227,5 +228,5 @@ class FaceItem(BaseModel):
     features: FaceFeatures
 
 
-class FaceDetectionDataClass(BaseModel):
+class FaceDetectionDataClass(NoRaiseBaseModel):
     items: Sequence[FaceItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/face_recognition/add_face/face_recognition_add_face_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/add_face/face_recognition_add_face_dataclass.py
@@ -1,7 +1,8 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List
 
 from pydantic import BaseModel
 
 
-class FaceRecognitionAddFaceDataClass(BaseModel):
+class FaceRecognitionAddFaceDataClass(NoRaiseBaseModel):
     face_ids: List[str]

--- a/edenai_apis/features/image/face_recognition/create_collection/face_recognition_create_collection_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/create_collection/face_recognition_create_collection_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class FaceRecognitionCreateCollectionDataClass(BaseModel):
+class FaceRecognitionCreateCollectionDataClass(NoRaiseBaseModel):
     collection_id: str

--- a/edenai_apis/features/image/face_recognition/delete_collection/face_recognition_delete_collection_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/delete_collection/face_recognition_delete_collection_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class FaceRecognitionDeleteCollectionDataClass(BaseModel):
+class FaceRecognitionDeleteCollectionDataClass(NoRaiseBaseModel):
     deleted: bool

--- a/edenai_apis/features/image/face_recognition/delete_face/face_recognition_delete_face_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/delete_face/face_recognition_delete_face_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class FaceRecognitionDeleteFaceDataClass(BaseModel):
+class FaceRecognitionDeleteFaceDataClass(NoRaiseBaseModel):
     deleted: bool

--- a/edenai_apis/features/image/face_recognition/list_collections/face_recognition_list_collections_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/list_collections/face_recognition_list_collections_dataclass.py
@@ -1,7 +1,8 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List
 
 from pydantic import BaseModel, Field
 
 
-class FaceRecognitionListCollectionsDataClass(BaseModel):
+class FaceRecognitionListCollectionsDataClass(NoRaiseBaseModel):
     collections: List[str] = Field(default_factory=list)

--- a/edenai_apis/features/image/face_recognition/list_faces/face_recognition_list_faces_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/list_faces/face_recognition_list_faces_dataclass.py
@@ -1,7 +1,8 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List
 
 from pydantic import BaseModel
 
 
-class FaceRecognitionListFacesDataClass(BaseModel):
+class FaceRecognitionListFacesDataClass(NoRaiseBaseModel):
     face_ids: List[str]

--- a/edenai_apis/features/image/face_recognition/recognize/face_recognition_recognize_dataclass.py
+++ b/edenai_apis/features/image/face_recognition/recognize/face_recognition_recognize_dataclass.py
@@ -1,12 +1,13 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List
 
 from pydantic import BaseModel, Field
 
 
-class FaceRecognitionRecognizedFaceDataClass(BaseModel):
+class FaceRecognitionRecognizedFaceDataClass(NoRaiseBaseModel):
     confidence: float
     face_id: str
 
 
-class FaceRecognitionRecognizeDataClass(BaseModel):
+class FaceRecognitionRecognizeDataClass(NoRaiseBaseModel):
     items: List[FaceRecognitionRecognizedFaceDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/image/generation/generation_dataclass.py
+++ b/edenai_apis/features/image/generation/generation_dataclass.py
@@ -1,12 +1,13 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class GeneratedImageDataClass(BaseModel):
+class GeneratedImageDataClass(NoRaiseBaseModel):
     image: str
     image_resource_url: StrictStr
 
 
-class GenerationDataClass(BaseModel):
+class GenerationDataClass(NoRaiseBaseModel):
     items: Sequence[GeneratedImageDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/image/landmark_detection/landmark_detection_dataclass.py
+++ b/edenai_apis/features/image/landmark_detection/landmark_detection_dataclass.py
@@ -1,28 +1,29 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class LandmarkVertice(BaseModel):
+class LandmarkVertice(NoRaiseBaseModel):
     x: int
     y: int
 
 
-class LandmarkLatLng(BaseModel):
+class LandmarkLatLng(NoRaiseBaseModel):
     latitude: float
     longitude: float
 
 
-class LandmarkLocation(BaseModel):
+class LandmarkLocation(NoRaiseBaseModel):
     lat_lng: LandmarkLatLng
 
 
-class LandmarkItem(BaseModel):
+class LandmarkItem(NoRaiseBaseModel):
     description: StrictStr
     confidence: float
     bounding_box: Sequence[LandmarkVertice] = Field(default_factory=list)
     locations: Sequence[LandmarkLocation] = Field(default_factory=list)
 
 
-class LandmarkDetectionDataClass(BaseModel):
+class LandmarkDetectionDataClass(NoRaiseBaseModel):
     items: Sequence[LandmarkItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/logo_detection/logo_detection_dataclass.py
+++ b/edenai_apis/features/image/logo_detection/logo_detection_dataclass.py
@@ -1,22 +1,23 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class LogoVertice(BaseModel):
+class LogoVertice(NoRaiseBaseModel):
     x: Optional[float]
     y: Optional[float]
 
 
-class LogoBoundingPoly(BaseModel):
+class LogoBoundingPoly(NoRaiseBaseModel):
     vertices: Sequence[LogoVertice]
 
 
-class LogoItem(BaseModel):
+class LogoItem(NoRaiseBaseModel):
     bounding_poly: Optional[LogoBoundingPoly]
     description: Optional[StrictStr]
     score: Optional[float]
 
 
-class LogoDetectionDataClass(BaseModel):
+class LogoDetectionDataClass(NoRaiseBaseModel):
     items: Sequence[LogoItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/object_detection/object_detection_dataclass.py
+++ b/edenai_apis/features/image/object_detection/object_detection_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, StrictStr, Field
 
 
-class ObjectItem(BaseModel):
+class ObjectItem(NoRaiseBaseModel):
     label: StrictStr
     confidence: float
     x_min: Optional[float]
@@ -12,5 +13,5 @@ class ObjectItem(BaseModel):
     y_max: Optional[float]
 
 
-class ObjectDetectionDataClass(BaseModel):
+class ObjectDetectionDataClass(NoRaiseBaseModel):
     items: Sequence[ObjectItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/question_answer/question_answer_dataclass.py
+++ b/edenai_apis/features/image/question_answer/question_answer_dataclass.py
@@ -1,7 +1,8 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field
 
 
-class QuestionAnswerDataClass(BaseModel):
+class QuestionAnswerDataClass(NoRaiseBaseModel):
     answers: Sequence[str] = Field(default_factory=list)

--- a/edenai_apis/features/image/search/delete_image/search_delete_image_dataclass.py
+++ b/edenai_apis/features/image/search/delete_image/search_delete_image_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class SearchDeleteImageDataClass(BaseModel):
+class SearchDeleteImageDataClass(NoRaiseBaseModel):
     status: str

--- a/edenai_apis/features/image/search/get_image/search_get_image_dataclass.py
+++ b/edenai_apis/features/image/search/get_image/search_get_image_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class SearchGetImageDataClass(BaseModel):
+class SearchGetImageDataClass(NoRaiseBaseModel):
     image: bytes

--- a/edenai_apis/features/image/search/get_images/search_get_images_dataclass.py
+++ b/edenai_apis/features/image/search/get_images/search_get_images_dataclass.py
@@ -1,11 +1,12 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class ImageSearchItem(BaseModel):
+class ImageSearchItem(NoRaiseBaseModel):
     image_name: StrictStr
 
 
-class SearchGetImagesDataClass(BaseModel):
+class SearchGetImagesDataClass(NoRaiseBaseModel):
     list_images: Sequence[ImageSearchItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/search/search_dataclass.py
+++ b/edenai_apis/features/image/search/search_dataclass.py
@@ -1,12 +1,13 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class ImageItem(BaseModel):
+class ImageItem(NoRaiseBaseModel):
     image_name: StrictStr
     score: float
 
 
-class SearchDataClass(BaseModel):
+class SearchDataClass(NoRaiseBaseModel):
     items: Sequence[ImageItem] = Field(default_factory=list)

--- a/edenai_apis/features/image/search/upload_image/search_upload_image_dataclass.py
+++ b/edenai_apis/features/image/search/upload_image/search_upload_image_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
 
-class SearchUploadImageDataClass(BaseModel):
+class SearchUploadImageDataClass(NoRaiseBaseModel):
     status: str

--- a/edenai_apis/features/ocr/anonymization_async/anonymization_async_dataclass.py
+++ b/edenai_apis/features/ocr/anonymization_async/anonymization_async_dataclass.py
@@ -1,5 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
 from pydantic import BaseModel
 
-class AnonymizationAsyncDataClass(BaseModel):
+class AnonymizationAsyncDataClass(NoRaiseBaseModel):
     document: str
     document_url : str

--- a/edenai_apis/features/ocr/bank_check_parsing/bank_check_parsing_dataclass.py
+++ b/edenai_apis/features/ocr/bank_check_parsing/bank_check_parsing_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field
 
 
-class MicrModel(BaseModel):
+class MicrModel(NoRaiseBaseModel):
     raw: Optional[str] = Field(...)
     account_number: Optional[str] = Field(...)
     routing_number: Optional[str] = Field(...)
@@ -11,7 +12,7 @@ class MicrModel(BaseModel):
     check_number: Optional[str] = Field(...)
 
 
-class ItemBankCheckParsingDataClass(BaseModel):
+class ItemBankCheckParsingDataClass(NoRaiseBaseModel):
     amount: Optional[float] = Field(...)
     amount_text: Optional[str] = Field(...)
     bank_address: Optional[str] = Field(...)
@@ -26,7 +27,7 @@ class ItemBankCheckParsingDataClass(BaseModel):
     micr: MicrModel = Field(...)
 
 
-class BankCheckParsingDataClass(BaseModel):
+class BankCheckParsingDataClass(NoRaiseBaseModel):
     extracted_data: Sequence[ItemBankCheckParsingDataClass] = Field(
         default_factory=list
     )

--- a/edenai_apis/features/ocr/custom_document_parsing_async/custom_document_parsing_async_dataclass.py
+++ b/edenai_apis/features/ocr/custom_document_parsing_async/custom_document_parsing_async_dataclass.py
@@ -1,16 +1,17 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class CustomDocumentParsingAsyncBoundingBox(BaseModel):
+class CustomDocumentParsingAsyncBoundingBox(NoRaiseBaseModel):
     left: Optional[float]
     top: Optional[float]
     width: Optional[float]
     height: Optional[float]
 
 
-class CustomDocumentParsingAsyncItem(BaseModel):
+class CustomDocumentParsingAsyncItem(NoRaiseBaseModel):
     confidence: float
     value: StrictStr
     query: StrictStr
@@ -18,5 +19,5 @@ class CustomDocumentParsingAsyncItem(BaseModel):
     page: int
 
 
-class CustomDocumentParsingAsyncDataClass(BaseModel):
+class CustomDocumentParsingAsyncDataClass(NoRaiseBaseModel):
     items: List[CustomDocumentParsingAsyncItem] = Field(default_factory=list)

--- a/edenai_apis/features/ocr/data_extraction/data_extraction_dataclass.py
+++ b/edenai_apis/features/ocr/data_extraction/data_extraction_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Any, Sequence, Optional
 
 from pydantic import BaseModel, Field, field_validator
@@ -5,7 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 from edenai_apis.utils.bounding_box import BoundingBox
 
 
-class ItemDataExtraction(BaseModel):
+class ItemDataExtraction(NoRaiseBaseModel):
     key: str
     value: Any
     bounding_box: BoundingBox
@@ -19,5 +20,5 @@ class ItemDataExtraction(BaseModel):
         return v
 
 
-class DataExtractionDataClass(BaseModel):
+class DataExtractionDataClass(NoRaiseBaseModel):
     fields: Sequence[ItemDataExtraction] = Field(default_factory=list)

--- a/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
+++ b/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 import datetime
 import json
 import os
@@ -30,7 +31,7 @@ def format_date(value: Any) -> Union[str, None]:
     return value.strftime("%Y-%m-%d")
 
 
-class Country(BaseModel):
+class Country(NoRaiseBaseModel):
     name: Optional[StrictStr]
     alpha2: Optional[StrictStr]
     alpha3: Optional[StrictStr]
@@ -70,12 +71,12 @@ def get_info_country(key: InfoCountry, value: StrictStr) -> Optional[Country]:
     return None
 
 
-class ItemIdentityParserDataClass(BaseModel):
+class ItemIdentityParserDataClass(NoRaiseBaseModel):
     value: Optional[StrictStr] = None
     confidence: Optional[float] = None
 
 
-class InfosIdentityParserDataClass(BaseModel):
+class InfosIdentityParserDataClass(NoRaiseBaseModel):
     last_name: ItemIdentityParserDataClass
     given_names: List[ItemIdentityParserDataClass] = Field(default_factory=list)
     birth_place: ItemIdentityParserDataClass
@@ -140,5 +141,5 @@ class InfosIdentityParserDataClass(BaseModel):
         )
 
 
-class IdentityParserDataClass(BaseModel):
+class IdentityParserDataClass(NoRaiseBaseModel):
     extracted_data: Sequence[InfosIdentityParserDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/ocr/invoice_parser/invoice_parser_dataclass.py
+++ b/edenai_apis/features/ocr/invoice_parser/invoice_parser_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class CustomerInformationInvoice(BaseModel):
+class CustomerInformationInvoice(NoRaiseBaseModel):
     customer_name: Optional[StrictStr]
     customer_address: Optional[StrictStr]  # Deprecated need to be removed
     customer_email: Optional[StrictStr]  # New
@@ -41,7 +42,7 @@ class CustomerInformationInvoice(BaseModel):
         )
 
 
-class MerchantInformationInvoice(BaseModel):
+class MerchantInformationInvoice(NoRaiseBaseModel):
     merchant_name: Optional[StrictStr]
     merchant_address: Optional[StrictStr]
     merchant_phone: Optional[StrictStr]  # New
@@ -75,7 +76,7 @@ class MerchantInformationInvoice(BaseModel):
         )
 
 
-class LocaleInvoice(BaseModel):
+class LocaleInvoice(NoRaiseBaseModel):
     currency: Optional[StrictStr]
     language: Optional[StrictStr]
 
@@ -84,7 +85,7 @@ class LocaleInvoice(BaseModel):
         return LocaleInvoice(currency=None, language=None)
 
 
-class ItemLinesInvoice(BaseModel):
+class ItemLinesInvoice(NoRaiseBaseModel):
     description: Optional[StrictStr] = None
     quantity: Optional[float] = None
     amount: Optional[float] = None
@@ -96,7 +97,7 @@ class ItemLinesInvoice(BaseModel):
     tax_rate: Optional[float] = None  # New
 
 
-class TaxesInvoice(BaseModel):
+class TaxesInvoice(NoRaiseBaseModel):
     value: Optional[float]
     rate: Optional[float]
 
@@ -105,7 +106,7 @@ class TaxesInvoice(BaseModel):
         return TaxesInvoice(value=None, rate=None)
 
 
-class BankInvoice(BaseModel):  # New obj
+class BankInvoice(NoRaiseBaseModel):  # New obj
     account_number: Optional[StrictStr]  # New
     iban: Optional[StrictStr]  # New
     bsb: Optional[StrictStr]  # New
@@ -127,7 +128,7 @@ class BankInvoice(BaseModel):  # New obj
         )
 
 
-class InfosInvoiceParserDataClass(BaseModel):
+class InfosInvoiceParserDataClass(NoRaiseBaseModel):
     customer_information: CustomerInformationInvoice = (
         CustomerInformationInvoice.default()
     )
@@ -161,5 +162,5 @@ class InfosInvoiceParserDataClass(BaseModel):
     item_lines: Sequence[ItemLinesInvoice] = Field(default_factory=list)
 
 
-class InvoiceParserDataClass(BaseModel):
+class InvoiceParserDataClass(NoRaiseBaseModel):
     extracted_data: Sequence[InfosInvoiceParserDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/ocr/ocr/ocr_dataclass.py
+++ b/edenai_apis/features/ocr/ocr/ocr_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class Bounding_box(BaseModel):
+class Bounding_box(NoRaiseBaseModel):
     text: Optional[StrictStr]
     left: Optional[float]
     top: Optional[float]
@@ -11,7 +12,7 @@ class Bounding_box(BaseModel):
     height: Optional[float]
 
 
-class OcrDataClass(BaseModel):
+class OcrDataClass(NoRaiseBaseModel):
     text: StrictStr
     bounding_boxes: Sequence[Bounding_box] = Field(default_factory=list)
 

--- a/edenai_apis/features/ocr/ocr_async/ocr_async_dataclass.py
+++ b/edenai_apis/features/ocr/ocr_async/ocr_async_dataclass.py
@@ -1,3 +1,6 @@
+from utils.parsing import NoRaiseBaseModel
+from utils.parsing import NoRaiseBaseModel<ESC> | update
+from utils.parsing import NoRaiseBaseModel<ESC> | update
 import enum
 from typing import List, Optional, Sequence, Callable
 
@@ -48,7 +51,7 @@ class CoordinateEnum(enum.Enum):
     Y = 1
 
 
-class BoundingBox(BaseModel):
+class BoundingBox(NoRaiseBaseModel):
     """Bounding box of a word in the image
 
 
@@ -152,7 +155,7 @@ class BoundingBox(BaseModel):
         return cls.from_json(boxes)
 
 
-class Word(BaseModel):
+class Word(NoRaiseBaseModel):
     """Word of a document
 
     Attributes:
@@ -175,7 +178,7 @@ class Word(BaseModel):
         return v
 
 
-class Line(BaseModel):
+class Line(NoRaiseBaseModel):
     """Line of a document
 
     Attributes:
@@ -189,8 +192,6 @@ class Line(BaseModel):
     words: Sequence[Word] = Field(default_factory=list, description="List of words")
     bounding_box: BoundingBox = Field(
         description="Bounding boxes of the words in the line"
-    )
-    confidence: Optional[float] = Field(..., description="Confidence of the line")
 
     @field_validator("confidence")
     @classmethod
@@ -201,7 +202,7 @@ class Line(BaseModel):
         return v
 
 
-class Page(BaseModel):
+class Page(NoRaiseBaseModel):
     """Page of a document
 
     Attributes:
@@ -211,7 +212,7 @@ class Page(BaseModel):
     lines: Sequence[Line] = Field(default_factory=list, description="List of lines")
 
 
-class OcrAsyncDataClass(BaseModel):
+class OcrAsyncDataClass(NoRaiseBaseModel):
     """OCR Async Data Class
 
     Attributes:

--- a/edenai_apis/features/ocr/ocr_tables_async/ocr_tables_async_dataclass.py
+++ b/edenai_apis/features/ocr/ocr_tables_async/ocr_tables_async_dataclass.py
@@ -1,16 +1,17 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class BoundixBoxOCRTable(BaseModel):
+class BoundixBoxOCRTable(NoRaiseBaseModel):
     left: Optional[float]
     top: Optional[float]
     width: Optional[float]
     height: Optional[float]
 
 
-class Cell(BaseModel):
+class Cell(NoRaiseBaseModel):
     text: Optional[StrictStr]
     row_index: Optional[int]
     col_index: Optional[int]
@@ -21,20 +22,20 @@ class Cell(BaseModel):
     is_header: bool = False
 
 
-class Row(BaseModel):
+class Row(NoRaiseBaseModel):
     cells: List[Cell] = Field(default_factory=list)
 
 
-class Table(BaseModel):
+class Table(NoRaiseBaseModel):
     rows: List[Row] = Field(default_factory=list)
     num_rows: Optional[int]
     num_cols: Optional[int]
 
 
-class Page(BaseModel):
+class Page(NoRaiseBaseModel):
     tables: List[Table] = Field(default_factory=list)
 
 
-class OcrTablesAsyncDataClass(BaseModel):
+class OcrTablesAsyncDataClass(NoRaiseBaseModel):
     pages: List[Page] = Field(default_factory=list)
     num_pages: Optional[int]

--- a/edenai_apis/features/ocr/receipt_parser/receipt_parser_dataclass.py
+++ b/edenai_apis/features/ocr/receipt_parser/receipt_parser_dataclass.py
@@ -1,13 +1,14 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class CustomerInformation(BaseModel):
+class CustomerInformation(NoRaiseBaseModel):
     customer_name: Optional[StrictStr] = None
 
 
-class MerchantInformation(BaseModel):
+class MerchantInformation(NoRaiseBaseModel):
     merchant_name: Optional[StrictStr] = None
     merchant_address: Optional[StrictStr] = None
     merchant_phone: Optional[StrictStr] = None
@@ -19,7 +20,7 @@ class MerchantInformation(BaseModel):
     merchant_abn_number: Optional[StrictStr] = None
 
 
-class PaymentInformation(BaseModel):
+class PaymentInformation(NoRaiseBaseModel):
     card_type: Optional[StrictStr] = None
     card_number: Optional[StrictStr] = None
     cash: Optional[StrictStr] = None
@@ -28,30 +29,30 @@ class PaymentInformation(BaseModel):
     change: Optional[StrictStr] = None
 
 
-class Locale(BaseModel):
+class Locale(NoRaiseBaseModel):
     currency: Optional[StrictStr] = None
     language: Optional[StrictStr] = None
     country: Optional[StrictStr] = None
 
 
-class ItemLines(BaseModel):
+class ItemLines(NoRaiseBaseModel):
     description: Optional[str] = None
     quantity: Optional[float] = None
     amount: Optional[float] = None
     unit_price: Optional[float] = None
 
 
-class Taxes(BaseModel):
+class Taxes(NoRaiseBaseModel):
     taxes: Optional[float] = None
     rate: Optional[float] = None
 
 
-class BarCode(BaseModel):
+class BarCode(NoRaiseBaseModel):
     value: str
     type: str
 
 
-class InfosReceiptParserDataClass(BaseModel):
+class InfosReceiptParserDataClass(NoRaiseBaseModel):
     invoice_number: Optional[StrictStr] = None
     invoice_total: Optional[float] = None
     invoice_subtotal: Optional[float] = None
@@ -71,5 +72,5 @@ class InfosReceiptParserDataClass(BaseModel):
     item_lines: Sequence[ItemLines] = Field(default_factory=list)
 
 
-class ReceiptParserDataClass(BaseModel):
+class ReceiptParserDataClass(NoRaiseBaseModel):
     extracted_data: Sequence[InfosReceiptParserDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/ocr/resume_parser/resume_parser_dataclass.py
+++ b/edenai_apis/features/ocr/resume_parser/resume_parser_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class ResumeLocation(BaseModel):
+class ResumeLocation(NoRaiseBaseModel):
     formatted_location: Optional[StrictStr]  # Affinda ?
     postal_code: Optional[StrictStr]  # All
     region: Optional[StrictStr]  # All
@@ -16,17 +17,17 @@ class ResumeLocation(BaseModel):
     city: Optional[str]  # All
 
 
-class ResumeSkill(BaseModel):
+class ResumeSkill(NoRaiseBaseModel):
     name: StrictStr
     type: Optional[StrictStr]
 
 
-class ResumeLang(BaseModel):
+class ResumeLang(NoRaiseBaseModel):
     name: StrictStr
     code: Optional[StrictStr]
 
 
-class ResumeWorkExpEntry(BaseModel):
+class ResumeWorkExpEntry(NoRaiseBaseModel):
     title: Optional[StrictStr]
     start_date: Optional[StrictStr]
     end_date: Optional[StrictStr]
@@ -36,12 +37,12 @@ class ResumeWorkExpEntry(BaseModel):
     industry: Optional[StrictStr]  # Hireability
 
 
-class ResumeWorkExp(BaseModel):
+class ResumeWorkExp(NoRaiseBaseModel):
     total_years_experience: Optional[StrictStr]  # Affinda
     entries: Sequence[ResumeWorkExpEntry] = Field(default_factory=list)
 
 
-class ResumeEducationEntry(BaseModel):
+class ResumeEducationEntry(NoRaiseBaseModel):
     title: Optional[StrictStr]
     start_date: Optional[StrictStr]
     end_date: Optional[StrictStr]
@@ -52,12 +53,12 @@ class ResumeEducationEntry(BaseModel):
     accreditation: Optional[StrictStr]  # Affinda
 
 
-class ResumeEducation(BaseModel):
+class ResumeEducation(NoRaiseBaseModel):
     total_years_education: Optional[int]
     entries: Sequence[ResumeEducationEntry] = Field(default_factory=list)
 
 
-class ResumePersonalName(BaseModel):
+class ResumePersonalName(NoRaiseBaseModel):
     first_name: Optional[StrictStr]  # all
     last_name: Optional[StrictStr]  # all
     raw_name: Optional[StrictStr]  # all
@@ -67,7 +68,7 @@ class ResumePersonalName(BaseModel):
     sufix: Optional[StrictStr]  # Affinda
 
 
-class ResumePersonalInfo(BaseModel):
+class ResumePersonalInfo(NoRaiseBaseModel):
     name: ResumePersonalName
     address: ResumeLocation
     self_summary: Optional[StrictStr]  # all
@@ -85,7 +86,7 @@ class ResumePersonalInfo(BaseModel):
     current_salary: Optional[StrictStr]  # Hireability
 
 
-class ResumeExtractedData(BaseModel):
+class ResumeExtractedData(NoRaiseBaseModel):
     personal_infos: ResumePersonalInfo
     education: ResumeEducation
     work_experience: ResumeWorkExp
@@ -97,5 +98,5 @@ class ResumeExtractedData(BaseModel):
     interests: Sequence[ResumeSkill] = Field(default_factory=list)
 
 
-class ResumeParserDataClass(BaseModel):
+class ResumeParserDataClass(NoRaiseBaseModel):
     extracted_data: ResumeExtractedData

--- a/edenai_apis/features/text/ai_detection/ai_detection_dataclass.py
+++ b/edenai_apis/features/text/ai_detection/ai_detection_dataclass.py
@@ -1,9 +1,13 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
+from utils.parsing import NoRaiseBaseModel
 
-class AiDetectionItem(BaseModel):
+
+
+class AiDetectionItem(NoRaiseBaseModel):
     text: str
     prediction: str
     ai_score: float
@@ -16,11 +20,12 @@ class AiDetectionItem(BaseModel):
             return "original"
 
     @field_validator("ai_score")
+    @classmethod
     def check_min_max(cls, v):
         if not 0 <= v <= 1:
             raise ValueError("Value should be between 0 and 1")
         return v
-    
+
     @staticmethod
     def set_label_based_on_human_score(human_score: float):
         if human_score > 0.5:
@@ -29,12 +34,13 @@ class AiDetectionItem(BaseModel):
             return "ai-generated"
 
 
-class AiDetectionDataClass(BaseModel):
+class AiDetectionDataClass(NoRaiseBaseModel):
     ai_score: float
     items: Sequence[AiDetectionItem] = Field(default_factory=list)
 
     @field_validator("ai_score")
+    @classmethod
     def check_min_max(cls, v):
-        if not 0 <= v <= 1:
+        if not 1 <= v <= 1:
             raise ValueError("Value should be between 0 and 1")
         return v

--- a/edenai_apis/features/text/anonymization/anonymization_dataclass.py
+++ b/edenai_apis/features/text/anonymization/anonymization_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict, Optional, Sequence, Union
 from pydantic import BaseModel, ConfigDict, Field, FieldSerializationInfo, field_serializer, field_validator, model_validator
 
@@ -45,7 +46,7 @@ SubCategoryType = Union[
 ]
 
 
-class AnonymizationEntity(BaseModel):
+class AnonymizationEntity(NoRaiseBaseModel):
     """This model represents an entity extracted from the text.
 
     Attributes:
@@ -99,7 +100,7 @@ class AnonymizationEntity(BaseModel):
         return value.value
 
 
-class AnonymizationDataClass(BaseModel):
+class AnonymizationDataClass(NoRaiseBaseModel):
     """This model represents the response from the API.
 
     Attributes:

--- a/edenai_apis/features/text/chat/chat_dataclass.py
+++ b/edenai_apis/features/text/chat/chat_dataclass.py
@@ -1,14 +1,15 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict, Generator, Optional, Sequence
 
 from pydantic import BaseModel, StrictStr, Field
 
 
-class ChatMessageDataClass(BaseModel):
+class ChatMessageDataClass(NoRaiseBaseModel):
     role: Optional[StrictStr]
     message: Optional[StrictStr]
 
 
-class ChatDataClass(BaseModel):
+class ChatDataClass(NoRaiseBaseModel):
     generated_text: StrictStr
     message: Sequence[ChatMessageDataClass] = Field(default_factory=list)
 
@@ -16,10 +17,10 @@ class ChatDataClass(BaseModel):
     def direct_response(api_response: Dict):
         return api_response["generated_text"]
 
-class ChatStreamResponse(BaseModel):
+class ChatStreamResponse(NoRaiseBaseModel):
     text: str
     blocked: bool
     provider: str
     
-class StreamChat(BaseModel):
+class StreamChat(NoRaiseBaseModel):
     stream: Generator[ChatStreamResponse, None, None]

--- a/edenai_apis/features/text/code_generation/code_generation_dataclass.py
+++ b/edenai_apis/features/text/code_generation/code_generation_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class CodeGenerationDataClass(BaseModel):
+class CodeGenerationDataClass(NoRaiseBaseModel):
     generated_text: StrictStr
 
     @staticmethod

--- a/edenai_apis/features/text/custom_classification/custom_classification_dataclass.py
+++ b/edenai_apis/features/text/custom_classification/custom_classification_dataclass.py
@@ -1,15 +1,16 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class ItemCustomClassificationDataClass(BaseModel):
+class ItemCustomClassificationDataClass(NoRaiseBaseModel):
     input: StrictStr
     label: StrictStr
     confidence: float
 
 
-class CustomClassificationDataClass(BaseModel):
+class CustomClassificationDataClass(NoRaiseBaseModel):
     classifications: Sequence[ItemCustomClassificationDataClass] = Field(
         default_factory=list
     )

--- a/edenai_apis/features/text/custom_named_entity_recognition/custom_named_entity_recognition_dataclass.py
+++ b/edenai_apis/features/text/custom_named_entity_recognition/custom_named_entity_recognition_dataclass.py
@@ -1,14 +1,15 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class InfosCustomNamedEntityRecognitionDataClass(BaseModel):
+class InfosCustomNamedEntityRecognitionDataClass(NoRaiseBaseModel):
     entity: StrictStr
     category: StrictStr
 
 
-class CustomNamedEntityRecognitionDataClass(BaseModel):
+class CustomNamedEntityRecognitionDataClass(NoRaiseBaseModel):
     items: Sequence[InfosCustomNamedEntityRecognitionDataClass] = Field(
         default_factory=list
     )

--- a/edenai_apis/features/text/embeddings/embeddings_dataclass.py
+++ b/edenai_apis/features/text/embeddings/embeddings_dataclass.py
@@ -1,11 +1,12 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field
 
 
-class EmbeddingDataClass(BaseModel):
+class EmbeddingDataClass(NoRaiseBaseModel):
     embedding: Sequence[float]
 
 
-class EmbeddingsDataClass(BaseModel):
+class EmbeddingsDataClass(NoRaiseBaseModel):
     items: Sequence[EmbeddingDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/emotion_detection/emotion_detection_dataclass.py
+++ b/edenai_apis/features/text/emotion_detection/emotion_detection_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from enum import Enum
 from typing import Sequence
 
@@ -18,7 +19,7 @@ class EmotionEnum(Enum):
         return cls[emotion.upper()].value
 
 
-class EmotionItem(BaseModel):
+class EmotionItem(NoRaiseBaseModel):
     """This class is used in EmotionAnalysisDataClass to list emotion analysed.
     Args:
         - emotion (EmotionEnum): emotion of the text
@@ -35,7 +36,7 @@ class EmotionItem(BaseModel):
         return v
 
 
-class EmotionDetectionDataClass(BaseModel):
+class EmotionDetectionDataClass(NoRaiseBaseModel):
     """This class is used to standardize the responses from emotion_detection.
     Args:
         - text (str) : The text analysed

--- a/edenai_apis/features/text/entity_sentiment/entity_sentiment_dataclass.py
+++ b/edenai_apis/features/text/entity_sentiment/entity_sentiment_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 
-class Entity(BaseModel):
+class Entity(NoRaiseBaseModel):
     type: StrictStr = Field(description="Recognized Entity type")
     text: StrictStr = Field(description="Text corresponding to the entity")
     sentiment: Literal["Positive", "Negative", "Neutral", "Mixed"]
@@ -11,5 +12,5 @@ class Entity(BaseModel):
     end_offset: Optional[StrictInt] = None
 
 
-class EntitySentimentDataClass(BaseModel):
+class EntitySentimentDataClass(NoRaiseBaseModel):
     items: List[Entity]

--- a/edenai_apis/features/text/generation/generation_dataclass.py
+++ b/edenai_apis/features/text/generation/generation_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class GenerationDataClass(BaseModel):
+class GenerationDataClass(NoRaiseBaseModel):
     generated_text: StrictStr
 
     @staticmethod

--- a/edenai_apis/features/text/keyword_extraction/keyword_extraction_dataclass.py
+++ b/edenai_apis/features/text/keyword_extraction/keyword_extraction_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class InfosKeywordExtractionDataClass(BaseModel):
+class InfosKeywordExtractionDataClass(NoRaiseBaseModel):
     keyword: str
     importance: Optional[float]
 
@@ -14,5 +15,5 @@ class InfosKeywordExtractionDataClass(BaseModel):
         return value
 
 
-class KeywordExtractionDataClass(BaseModel):
+class KeywordExtractionDataClass(NoRaiseBaseModel):
     items: Sequence[InfosKeywordExtractionDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/moderation/moderation_dataclass.py
+++ b/edenai_apis/features/text/moderation/moderation_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from enum import Enum
 from typing import Sequence, Union
 
@@ -35,7 +36,7 @@ class TextModerationCategoriesMicrosoftEnum(Enum):
     Category3 = "offensive"
 
 
-class TextModerationItem(BaseModel):
+class TextModerationItem(NoRaiseBaseModel):
     label: StrictStr
     likelihood: int
     category: CategoryType
@@ -47,7 +48,7 @@ class TextModerationItem(BaseModel):
     def serialize_subcategory(self, value: SubCategoryType, _: FieldSerializationInfo):
         return value.value
 
-class ModerationDataClass(BaseModel):
+class ModerationDataClass(NoRaiseBaseModel):
     nsfw_likelihood: int
     items: Sequence[TextModerationItem] = Field(default_factory=list)
     nsfw_likelihood_score : float

--- a/edenai_apis/features/text/named_entity_recognition/named_entity_recognition_dataclass.py
+++ b/edenai_apis/features/text/named_entity_recognition/named_entity_recognition_dataclass.py
@@ -1,13 +1,14 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class InfosNamedEntityRecognitionDataClass(BaseModel):
+class InfosNamedEntityRecognitionDataClass(NoRaiseBaseModel):
     entity: StrictStr
     category: Optional[StrictStr]
     importance: Optional[float]
 
 
-class NamedEntityRecognitionDataClass(BaseModel):
+class NamedEntityRecognitionDataClass(NoRaiseBaseModel):
     items: Sequence[InfosNamedEntityRecognitionDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/plagia_detection/plagia_detection_dataclass.py
+++ b/edenai_apis/features/text/plagia_detection/plagia_detection_dataclass.py
@@ -1,10 +1,11 @@
+from utils.parsing import NoRaiseBaseModel
 
 from typing import Sequence
 
 from pydantic import BaseModel, Field, root_validator, field_validator
 
 
-class PlagiaDetectionCandidate(BaseModel):
+class PlagiaDetectionCandidate(NoRaiseBaseModel):
     url: str
     plagia_score: float
     prediction: str
@@ -26,11 +27,11 @@ class PlagiaDetectionCandidate(BaseModel):
             raise ValueError("Value should be between 0 and 1")
         return v
 
-class PlagiaDetectionItem(BaseModel):
+class PlagiaDetectionItem(NoRaiseBaseModel):
     text: str
     candidates: Sequence[PlagiaDetectionCandidate] = Field(default_factory=list)
 
 
-class PlagiaDetectionDataClass(BaseModel):
+class PlagiaDetectionDataClass(NoRaiseBaseModel):
     plagia_score : float
     items : Sequence[PlagiaDetectionItem] = Field(default_factory=list)

--- a/edenai_apis/features/text/prompt_optimization/prompt_optimization_dataclass.py
+++ b/edenai_apis/features/text/prompt_optimization/prompt_optimization_dataclass.py
@@ -1,12 +1,13 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, StrictStr, Field
 
 
-class PromptDataClass(BaseModel):
+class PromptDataClass(NoRaiseBaseModel):
     text: StrictStr
 
 
-class PromptOptimizationDataClass(BaseModel):
+class PromptOptimizationDataClass(NoRaiseBaseModel):
     missing_information: StrictStr
     items: Sequence[PromptDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/question_answer/question_answer_dataclass.py
+++ b/edenai_apis/features/text/question_answer/question_answer_dataclass.py
@@ -1,7 +1,8 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field
 
 
-class QuestionAnswerDataClass(BaseModel):
+class QuestionAnswerDataClass(NoRaiseBaseModel):
     answers: Sequence[str] = Field(default_factory=list)

--- a/edenai_apis/features/text/search/search_dataclass.py
+++ b/edenai_apis/features/text/search/search_dataclass.py
@@ -1,13 +1,14 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class InfosSearchDataClass(BaseModel):
+class InfosSearchDataClass(NoRaiseBaseModel):
     object: StrictStr
     document: int
     score: float
 
 
-class SearchDataClass(BaseModel):
+class SearchDataClass(NoRaiseBaseModel):
     items: Sequence[InfosSearchDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/sentiment_analysis/sentiment_analysis_dataclass.py
+++ b/edenai_apis/features/text/sentiment_analysis/sentiment_analysis_dataclass.py
@@ -1,3 +1,4 @@
+from utils.parsing import NoRaiseBaseModel
 from enum import Enum
 from typing import Optional, Sequence, Literal
 
@@ -10,7 +11,7 @@ class SentimentEnum(Enum):
     NEUTRAL = "Neutral"
 
 
-class SegmentSentimentAnalysisDataClass(BaseModel):
+class SegmentSentimentAnalysisDataClass(NoRaiseBaseModel):
     """This class is used in SentimentAnalysisDataClass to describe each segment analyzed.
 
     Args:
@@ -52,7 +53,7 @@ class SegmentSentimentAnalysisDataClass(BaseModel):
         return round(value, 2)
 
 
-class SentimentAnalysisDataClass(BaseModel):
+class SentimentAnalysisDataClass(NoRaiseBaseModel):
     """This class is used to standardize responses from sentiment_analysis.
     Args:
         - text (str): The text whose has been analyzed

--- a/edenai_apis/features/text/spell_check/spell_check_dataclass.py
+++ b/edenai_apis/features/text/spell_check/spell_check_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence, List
 
 from pydantic import BaseModel, Field
 
 
-class SuggestionItem(BaseModel):
+class SuggestionItem(NoRaiseBaseModel):
     """
     Represents a suggestion for a misspelled word.
 
@@ -22,7 +23,7 @@ class SuggestionItem(BaseModel):
     score: Optional[float] = Field(ge=0, le=1)
 
 
-class SpellCheckItem(BaseModel):
+class SpellCheckItem(NoRaiseBaseModel):
     """Represents a spell check item with suggestions.
 
     Args:
@@ -46,7 +47,7 @@ class SpellCheckItem(BaseModel):
     suggestions: List[SuggestionItem] = Field(default_factory=list)
 
 
-class SpellCheckDataClass(BaseModel):
+class SpellCheckDataClass(NoRaiseBaseModel):
     """
     Represents a spell check model with a list of spell check items.
 

--- a/edenai_apis/features/text/summarize/summarize_dataclass.py
+++ b/edenai_apis/features/text/summarize/summarize_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class SummarizeDataClass(BaseModel):
+class SummarizeDataClass(NoRaiseBaseModel):
     result: StrictStr
 
     @staticmethod

--- a/edenai_apis/features/text/syntax_analysis/syntax_analysis_dataclass.py
+++ b/edenai_apis/features/text/syntax_analysis/syntax_analysis_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class InfosSyntaxAnalysisDataClass(BaseModel):
+class InfosSyntaxAnalysisDataClass(NoRaiseBaseModel):
     word: StrictStr
     importance: Optional[float]
     tag: StrictStr
@@ -11,5 +12,5 @@ class InfosSyntaxAnalysisDataClass(BaseModel):
     others: Optional[Dict[str, object]] = Field(default_factory=dict)
 
 
-class SyntaxAnalysisDataClass(BaseModel):
+class SyntaxAnalysisDataClass(NoRaiseBaseModel):
     items: Sequence[InfosSyntaxAnalysisDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/text/topic_extraction/topic_extraction_dataclass.py
+++ b/edenai_apis/features/text/topic_extraction/topic_extraction_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class ExtractedTopic(BaseModel):
+class ExtractedTopic(NoRaiseBaseModel):
     category: str
     importance: float
 
@@ -27,5 +28,5 @@ class ExtractedTopic(BaseModel):
         return round(value, 2)
 
 
-class TopicExtractionDataClass(BaseModel):
+class TopicExtractionDataClass(NoRaiseBaseModel):
     items: Sequence[ExtractedTopic] = Field(default_factory=list)

--- a/edenai_apis/features/translation/automatic_translation/automatic_translation_dataclass.py
+++ b/edenai_apis/features/translation/automatic_translation/automatic_translation_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class AutomaticTranslationDataClass(BaseModel):
+class AutomaticTranslationDataClass(NoRaiseBaseModel):
     text: StrictStr
 
     @staticmethod

--- a/edenai_apis/features/translation/document_translation/document_translation_dataclass.py
+++ b/edenai_apis/features/translation/document_translation/document_translation_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Dict
 
 from pydantic import BaseModel, StrictStr
 
 
-class DocumentTranslationDataClass(BaseModel):
+class DocumentTranslationDataClass(NoRaiseBaseModel):
     file: str
     document_resource_url: StrictStr
 

--- a/edenai_apis/features/translation/language_detection/language_detection_dataclass.py
+++ b/edenai_apis/features/translation/language_detection/language_detection_dataclass.py
@@ -1,9 +1,10 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence, Optional
 
 from pydantic import BaseModel, Field, StrictStr, field_validator
 
 
-class InfosLanguageDetectionDataClass(BaseModel):
+class InfosLanguageDetectionDataClass(NoRaiseBaseModel):
     language: StrictStr
     display_name: StrictStr
     confidence: Optional[float]
@@ -16,5 +17,5 @@ class InfosLanguageDetectionDataClass(BaseModel):
         return round(value, 2)
 
 
-class LanguageDetectionDataClass(BaseModel):
+class LanguageDetectionDataClass(NoRaiseBaseModel):
     items: Sequence[InfosLanguageDetectionDataClass] = Field(default_factory=list)

--- a/edenai_apis/features/video/explicit_content_detection_async/explicit_content_detection_async_dataclass.py
+++ b/edenai_apis/features/video/explicit_content_detection_async/explicit_content_detection_async_dataclass.py
@@ -1,13 +1,14 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class ContentNSFW(BaseModel):
+class ContentNSFW(NoRaiseBaseModel):
     timestamp: float
     confidence: float
     category: StrictStr
 
 
-class ExplicitContentDetectionAsyncDataClass(BaseModel):
+class ExplicitContentDetectionAsyncDataClass(NoRaiseBaseModel):
     moderation: Sequence[ContentNSFW] = Field(default_factory=list)

--- a/edenai_apis/features/video/face_detection_async/face_detection_async_dataclass.py
+++ b/edenai_apis/features/video/face_detection_async/face_detection_async_dataclass.py
@@ -1,22 +1,23 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field
 
 
-class VideoBoundingBox(BaseModel):
+class VideoBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class VideoFacePoses(BaseModel):
+class VideoFacePoses(NoRaiseBaseModel):
     pitch: Optional[float]
     roll: Optional[float]
     yawn: Optional[float]
 
 
-class FaceAttributes(BaseModel):
+class FaceAttributes(NoRaiseBaseModel):
     headwear: Optional[float]
     frontal_gaze: Optional[float]
     eyes_visible: Optional[float]
@@ -28,7 +29,7 @@ class FaceAttributes(BaseModel):
     pose: VideoFacePoses
 
 
-class LandmarksVideo(BaseModel):
+class LandmarksVideo(NoRaiseBaseModel):
     eye_left: Sequence[float] = Field(default_factory=list)
     eye_right: Sequence[float] = Field(default_factory=list)
     nose: Sequence[float] = Field(default_factory=list)
@@ -36,12 +37,12 @@ class LandmarksVideo(BaseModel):
     mouth_right: Sequence[float] = Field(default_factory=list)
 
 
-class VideoFace(BaseModel):
+class VideoFace(NoRaiseBaseModel):
     offset: Optional[float]
     bounding_box: VideoBoundingBox
     attributes: FaceAttributes
     landmarks: LandmarksVideo
 
 
-class FaceDetectionAsyncDataClass(BaseModel):
+class FaceDetectionAsyncDataClass(NoRaiseBaseModel):
     faces: Sequence[VideoFace] = Field(default_factory=list)

--- a/edenai_apis/features/video/label_detection_async/label_detection_async_dataclass.py
+++ b/edenai_apis/features/video/label_detection_async/label_detection_async_dataclass.py
@@ -1,21 +1,22 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class VideoLabelBoundingBox(BaseModel):
+class VideoLabelBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class VideoLabelTimeStamp(BaseModel):
+class VideoLabelTimeStamp(NoRaiseBaseModel):
     start: Optional[float]
     end: Optional[float]
 
 
-class VideoLabel(BaseModel):
+class VideoLabel(NoRaiseBaseModel):
     name: StrictStr
     confidence: float
     timestamp: Sequence[VideoLabelTimeStamp] = Field(default_factory=list)
@@ -23,5 +24,5 @@ class VideoLabel(BaseModel):
     bounding_box: Sequence[VideoLabelBoundingBox] = Field(default_factory=list)
 
 
-class LabelDetectionAsyncDataClass(BaseModel):
+class LabelDetectionAsyncDataClass(NoRaiseBaseModel):
     labels: Sequence[VideoLabel] = Field(default_factory=list)

--- a/edenai_apis/features/video/logo_detection_async/logo_detection_async_dataclass.py
+++ b/edenai_apis/features/video/logo_detection_async/logo_detection_async_dataclass.py
@@ -1,25 +1,26 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class VideoLogoBoundingBox(BaseModel):
+class VideoLogoBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class VideoLogo(BaseModel):
+class VideoLogo(NoRaiseBaseModel):
     timestamp: float
     bounding_box: VideoLogoBoundingBox
     confidence: Optional[float]
 
 
-class LogoTrack(BaseModel):
+class LogoTrack(NoRaiseBaseModel):
     description: StrictStr
     tracking: Sequence[VideoLogo] = Field(default_factory=list)
 
 
-class LogoDetectionAsyncDataClass(BaseModel):
+class LogoDetectionAsyncDataClass(NoRaiseBaseModel):
     logos: Sequence[LogoTrack] = Field(default_factory=list)

--- a/edenai_apis/features/video/object_tracking_async/object_tracking_async_dataclass.py
+++ b/edenai_apis/features/video/object_tracking_async/object_tracking_async_dataclass.py
@@ -1,25 +1,26 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class VideoObjectBoundingBox(BaseModel):
+class VideoObjectBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class ObjectFrame(BaseModel):
+class ObjectFrame(NoRaiseBaseModel):
     timestamp: float
     bounding_box: VideoObjectBoundingBox
 
 
-class ObjectTrack(BaseModel):
+class ObjectTrack(NoRaiseBaseModel):
     description: StrictStr
     confidence: float
     frames: Sequence[ObjectFrame] = Field(default_factory=list)
 
 
-class ObjectTrackingAsyncDataClass(BaseModel):
+class ObjectTrackingAsyncDataClass(NoRaiseBaseModel):
     objects: Sequence[ObjectTrack] = Field(default_factory=list)

--- a/edenai_apis/features/video/person_tracking_async/person_tracking_async_dataclass.py
+++ b/edenai_apis/features/video/person_tracking_async/person_tracking_async_dataclass.py
@@ -1,31 +1,32 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class UpperCloth(BaseModel):
+class UpperCloth(NoRaiseBaseModel):
     value: StrictStr
     confidence: float
 
 
-class LowerCloth(BaseModel):
+class LowerCloth(NoRaiseBaseModel):
     value: StrictStr
     confidence: float
 
 
-class PersonAttributes(BaseModel):
+class PersonAttributes(NoRaiseBaseModel):
     upper_cloths: Sequence[UpperCloth] = Field(default_factory=list)
     lower_cloths: Sequence[LowerCloth] = Field(default_factory=list)
 
 
-class VideoTrackingBoundingBox(BaseModel):
+class VideoTrackingBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class PersonLandmarks(BaseModel):
+class PersonLandmarks(NoRaiseBaseModel):
     eye_left: Sequence[float] = Field(default_factory=list)
     eye_right: Sequence[float] = Field(default_factory=list)
     nose: Sequence[float] = Field(default_factory=list)
@@ -47,7 +48,7 @@ class PersonLandmarks(BaseModel):
     mouth_right: Sequence[float] = Field(default_factory=list)
 
 
-class VideoPersonPoses(BaseModel):
+class VideoPersonPoses(NoRaiseBaseModel):
     pitch: Optional[float]
     roll: Optional[float]
     yaw: Optional[float]
@@ -61,7 +62,7 @@ class VideoPersonPoses(BaseModel):
         )
 
 
-class VideoPersonQuality(BaseModel):
+class VideoPersonQuality(NoRaiseBaseModel):
     brightness: Optional[float]
     sharpness: Optional[float]
 
@@ -73,7 +74,7 @@ class VideoPersonQuality(BaseModel):
         )
 
 
-class PersonTracking(BaseModel):
+class PersonTracking(NoRaiseBaseModel):
     offset: float
     attributes: PersonAttributes = Field(default_factory=PersonAttributes)
     landmarks: PersonLandmarks = Field(default_factory=PersonLandmarks)
@@ -82,9 +83,9 @@ class PersonTracking(BaseModel):
     bounding_box: VideoTrackingBoundingBox
 
 
-class VideoTrackingPerson(BaseModel):
+class VideoTrackingPerson(NoRaiseBaseModel):
     tracked: Sequence[PersonTracking] = Field(default_factory=list)
 
 
-class PersonTrackingAsyncDataClass(BaseModel):
+class PersonTrackingAsyncDataClass(NoRaiseBaseModel):
     persons: Sequence[VideoTrackingPerson] = Field(default_factory=list)

--- a/edenai_apis/features/video/text_detection_async/text_detection_async_dataclass.py
+++ b/edenai_apis/features/video/text_detection_async/text_detection_async_dataclass.py
@@ -1,25 +1,26 @@
+from utils.parsing import NoRaiseBaseModel
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, StrictStr
 
 
-class VideoTextBoundingBox(BaseModel):
+class VideoTextBoundingBox(NoRaiseBaseModel):
     top: Optional[float]
     left: Optional[float]
     height: Optional[float]
     width: Optional[float]
 
 
-class VideoTextFrames(BaseModel):
+class VideoTextFrames(NoRaiseBaseModel):
     confidence: float
     timestamp: float
     bounding_box: VideoTextBoundingBox
 
 
-class VideoText(BaseModel):
+class VideoText(NoRaiseBaseModel):
     text: StrictStr
     frames: Sequence[VideoTextFrames] = Field(default_factory=list)
 
 
-class TextDetectionAsyncDataClass(BaseModel):
+class TextDetectionAsyncDataClass(NoRaiseBaseModel):
     texts: Sequence[VideoText] = Field(default_factory=list)

--- a/edenai_apis/tests/utils/test_custom_base_model.py
+++ b/edenai_apis/tests/utils/test_custom_base_model.py
@@ -1,0 +1,70 @@
+"""
+Test our custom implementation of pydantic.BaseModel
+"""
+from edenai_apis.utils.parsing import NoRaiseBaseModel
+
+
+class TestModel(NoRaiseBaseModel):
+    expect_string: str
+    expect_float: float
+    expect_int: int
+
+
+class TestModelWithNestedType(NoRaiseBaseModel):
+    expect_dict: dict
+    expect_list: list
+    expect_model: TestModel
+
+
+def test_validation_error_all_wrong_should_not_raise_exception():
+    """should not raise exception, should set all values to None"""
+    test_model = TestModel(expect_int="1", expect_float="1.0", expect_string=1)
+    assert any(val is None for val in test_model.model_dump().values())
+
+
+def test_validation_all_valid():
+    test_model = TestModel(expect_int=1, expect_float=1.0, expect_string="one")
+    assert test_model.expect_int == 1
+    assert test_model.expect_float == 1.0
+    assert test_model.expect_string == "one"
+
+
+def test_validation_error_some_wrong_should_not_raise_exception():
+    """
+    should not raise exception,
+    should set all wrong values to None
+    should set valid values
+    """
+    test_model = TestModel(expect_int=1, expect_float="one", expect_string="1")
+    assert test_model.expect_int == 1
+    assert test_model.expect_float is None
+    assert test_model.expect_string == "1"
+
+
+def test_extra_field_should_not_be_present_in_result():
+    test_model = TestModel(
+        expect_int=1,
+        expect_float=1.0,
+        expect_string="",
+        extra_field="this field should not appear in test_model",
+    )
+    assert not hasattr(test_model, "extra_field")
+
+
+def test_with_nested_types():
+    test_model = TestModel(
+        expect_int=1,
+        expect_float=1.0,
+        expect_string="",
+        extra_field="this field should not appear in test_model",
+    )
+    # no exception should be raised
+    nest_model = TestModelWithNestedType(
+        expect_dict=[], expect_list={}, expect_model=test_model
+    )
+
+    assert nest_model.expect_model.expect_int == 1
+    assert nest_model.expect_model.expect_float == 1.0
+    assert nest_model.expect_model.expect_string == ""
+    assert nest_model.expect_dict is None
+    assert nest_model.expect_list is None


### PR DESCRIPTION
Catch validation errors on pydantic models used for providers responses standardization

The ValidationError will be logged instead and the invalid field will be set to None

Allow us to still get a partial response instead of receving an error when provider return unexpected fields 