### PR TITLE
[fix] return image in the get upload async phase.

### DIFF
--- a/edenai_apis/apis/nyckel/nyckel_api.py
+++ b/edenai_apis/apis/nyckel/nyckel_api.py
@@ -415,6 +415,7 @@ class NyckelApi(ProviderInterface, ImageInterface):
             original_response=original_response,
             standardized_response=AutomlClassificationUploadDataAsyncDataClass(
                 message="Data uploaded successfully",
+                image=original_response.get("data"),
                 label_name=original_response.get("label_name"),
             ),
             provider_job_id=provider_job_id,

--- a/edenai_apis/features/image/automl_classification/upload_data_async/automl_classification_upload_data_async_dataclass.py
+++ b/edenai_apis/features/image/automl_classification/upload_data_async/automl_classification_upload_data_async_dataclass.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictStr
 
 
 class AutomlClassificationUploadDataAsyncDataClass(BaseModel):
     message: str
+    image: StrictStr
     label_name: str


### PR DESCRIPTION
- right now we need to use show original response to have the uploaded image.

- Return directly the image during the upload image async phase.