### PR TITLE
Eaiscrum 949 user error getting billed on provider errors nickel

### DIFF
--- a/edenai_apis/apis/nyckel/nyckel_api.py
+++ b/edenai_apis/apis/nyckel/nyckel_api.py
@@ -156,7 +156,8 @@ class NyckelApi(ProviderInterface, ImageInterface):
         # The response 'data' key points to a url where we can fetch the image.
         try:
             fetch_image_response = requests.get(response.json()[0]["data"])
-            fetch_image_response.raise_for_status()
+            if fetch_image_response.status_code >= 400:
+                self._raise_provider_exception(url, {}, fetch_image_response)
         except IndexError:
             raise ProviderException(f"Image '{image_name}' not found.")
         except Exception:


### PR DESCRIPTION
Nickel returned some providers errors when getting images without any status code with a typical error message when no message is provided or the exception is not handled: `Provider has returned an error. Please try again later`. So the user was getting charged as we don't charge only if there is a **status_code** that is `>=400`