### PR TITLE
[fix] don't raise Error if wrong date format

### DIFF
--- a/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
+++ b/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
@@ -114,14 +114,12 @@ class InfosIdentityParserDataClass(BaseModel):
 
     @field_validator("expire_date", "issuance_date", "birth_date")
     def date_validator(cls, value, info: ValidationInfo):
-        none_val = {"value": None, "confidence": None}
         if not value.value:
-            return none_val
+            return {"value": None, "confidence": None}
         try:
             datetime.datetime.strptime(value.value, "%Y-%m-%d")
         except ValueError:
             logging.warning(f"Incorrect date format received on {info.field_name}, format should be YYYY-MM-DD. Got: {value.value}")
-            return none_val
         return value
 
     @staticmethod

--- a/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
+++ b/edenai_apis/features/ocr/identity_parser/identity_parser_dataclass.py
@@ -1,3 +1,4 @@
+import logging
 import datetime
 import json
 import os
@@ -10,6 +11,7 @@ from pydantic import (
     Field,
     StrictStr,
     field_validator,
+    ValidationInfo
 )
 
 
@@ -111,13 +113,15 @@ class InfosIdentityParserDataClass(BaseModel):
         return value
 
     @field_validator("expire_date", "issuance_date", "birth_date")
-    def date_validator(cls, value):
+    def date_validator(cls, value, info: ValidationInfo):
+        none_val = {"value": None, "confidence": None}
         if not value.value:
-            return {"value": None, "confidence": None}
+            return none_val
         try:
             datetime.datetime.strptime(value.value, "%Y-%m-%d")
         except ValueError:
-            raise ValueError("Incorrect data format, should be YYYY-MM-DD")
+            logging.warning(f"Incorrect date format received on {info.field_name}, format should be YYYY-MM-DD. Got: {value.value}")
+            return none_val
         return value
 
     @staticmethod


### PR DESCRIPTION
## Before:
Raises pydantic's `ValidationError` if date format is not right. 

## Now:
logs error and return the field as `None`.

__Reason:__  I think we shouldn't panic when just one field is invalid, we should just set said field to `None` instead.

I put a `logging.warning`, not sure of the log level I should put.