### PR TITLE
[Fix] nyckel sample id already exist

### DIFF
--- a/edenai_apis/apis/nyckel/nyckel_api.py
+++ b/edenai_apis/apis/nyckel/nyckel_api.py
@@ -301,13 +301,13 @@ class NyckelApi(ProviderInterface, ImageInterface):
 
         url = f"https://www.nyckel.com/v1/functions/{project_id}/labels"
         payload = {"name": label_name, "description": label_description}
-        response = self._session.post(url, json=payload)
         try:
+            response = self._session.post(url, json=payload)
             original_response = response.json()
-        except json.JSONDecodeError as exp:
+        except:
             raise ProviderException(
                 "Something went wrong when creating the label !!", 500
-            ) from exp
+            )
         if (
             response.status_code >= 400
             and "already exists" not in original_response.get("message", "")

--- a/edenai_apis/apis/nyckel/nyckel_api.py
+++ b/edenai_apis/apis/nyckel/nyckel_api.py
@@ -304,10 +304,10 @@ class NyckelApi(ProviderInterface, ImageInterface):
         response = self._session.post(url, json=payload)
         try:
             original_response = response.json()
-        except:
+        except json.JSONDecodeError as exp:
             raise ProviderException(
                 "Something went wrong when creating the label !!", 500
-            )
+            ) from exp
         if (
             response.status_code >= 400
             and "already exists" not in original_response.get("message", "")


### PR DESCRIPTION
- The way Nyckel works, you can upload an image without any label then you can annotate your image with a label that you created.

- Technically you can add the labelName when you upload an image and if the label does not exist it will created (does not work always & sometimes they create the label two times even if they have the same name)

- Now we remove the retry by creating directly the label before uploading the image.

