### PR TITLE
Fix resume parsing total_years_experience when 0

### DIFF
--- a/edenai_apis/apis/affinda/standardization.py
+++ b/edenai_apis/apis/affinda/standardization.py
@@ -202,9 +202,13 @@ class ResumeStandardizer:
                     industry=None,
                 )
             )
+
         total_years = extract(self.__data, ["totalYearsExperience", "parsed"])
-        if total_years:
+
+        if isinstance(total_years, (int, float)):
             total_years = str(total_years)
+        else:
+            total_years = None
 
         self.__std_response["work_experience"] = ResumeWorkExp(
             total_years_experience=total_years,


### PR DESCRIPTION
if total_years was 0, it didnt convert to string, but kept 0. Therefore pydantic validation failed