### PR TITLE
include new models from db for replicate

### DIFF
--- a/edenai_apis/features/image/generation/generation_args.py
+++ b/edenai_apis/features/image/generation/generation_args.py
@@ -10,6 +10,6 @@ def generation_arguments(provider_name: str) -> Dict:
             "amazon": "titan-image-generator-v1_premium",
             "openai": "dall-e-3",
             "stabilityai": "stable-diffusion-xl-1024-v1-0",
-            "replicate": "classic",
+            "replicate": "black-forest-labs/flux-pro",
         },
     }


### PR DESCRIPTION
Old models used a "version" ID in the payload, while new models use the name directly in the URL

now we can add new models from the database and still support the old models