### PR TITLE
Fix/rm webhooks

### DIFF
--- a/edenai_apis/apis/google/google_video_api.py
+++ b/edenai_apis/apis/google/google_video_api.py
@@ -1,22 +1,26 @@
-from pathlib import Path
-from time import time, sleep
-from typing import List, Dict, Any
-import requests
+import base64
 import json
+from datetime import datetime, timezone
+from pathlib import Path
+from time import sleep, time
+from typing import Any, Dict, List
 
+import requests
+from dateutil.parser import parse
 from google.cloud import videointelligence
 
+from edenai_apis.apis.amazon.helpers import check_webhook_result
 from edenai_apis.apis.google.google_helpers import (
     GoogleVideoFeatures,
+    calculate_usage_tokens,
     google_video_get_job,
     score_to_content,
-    calculate_usage_tokens,
 )
 from edenai_apis.features.video import (
     ContentNSFW,
     ExplicitContentDetectionAsyncDataClass,
-    QuestionAnswerDataClass,
     QuestionAnswerAsyncDataClass,
+    QuestionAnswerDataClass,
 )
 from edenai_apis.features.video.face_detection_async.face_detection_async_dataclass import (
     FaceAttributes,
@@ -55,17 +59,16 @@ from edenai_apis.features.video.person_tracking_async.person_tracking_async_data
     VideoTrackingBoundingBox,
     VideoTrackingPerson,
 )
+from edenai_apis.features.video.shot_change_detection_async.shot_change_detection_async_dataclass import (
+    ShotChangeDetectionAsyncDataClass,
+    ShotFrame,
+)
 from edenai_apis.features.video.text_detection_async.text_detection_async_dataclass import (
     TextDetectionAsyncDataClass,
     VideoText,
     VideoTextBoundingBox,
     VideoTextFrames,
 )
-from edenai_apis.features.video.shot_change_detection_async.shot_change_detection_async_dataclass import (
-    ShotChangeDetectionAsyncDataClass,
-    ShotFrame,
-)
-from edenai_apis.apis.amazon.helpers import check_webhook_result
 from edenai_apis.features.video.video_interface import VideoInterface
 from edenai_apis.utils.exception import ProviderException
 from edenai_apis.utils.types import (
@@ -75,8 +78,6 @@ from edenai_apis.utils.types import (
     AsyncResponseType,
     ResponseType,
 )
-from datetime import datetime, timezone
-from dateutil.parser import parse
 
 
 class GoogleVideoApi(VideoInterface):
@@ -727,7 +728,6 @@ class GoogleVideoApi(VideoInterface):
     ) -> AsyncBaseResponseType[ShotChangeDetectionAsyncDataClass]:
 
         result = google_video_get_job(provider_job_id)
-        print(result)
         if result.get("done"):
             response = result["response"]["annotationResults"][0]
             shot_annotations = response.get("shotAnnotations", [])
@@ -834,23 +834,23 @@ class GoogleVideoApi(VideoInterface):
         file: str,
         file_url: str = "",
         temperature: float = 0,
-        model: str = None,
+        model: str | None = None,
     ) -> AsyncLaunchJobResponseType:
         data_job_id = {}
         api_key = self.api_settings.get("genai_api_key")
         file_data = self._upload_and_process_file(file, api_key)
-        job_id = file_data["name"].split("/")[1]
+        process_file_id = file_data["name"].split("/")[1]
+
         inputs = {
             "text": text,
             "temperature": temperature,
             "model": model,
+            "process_file_id": process_file_id,
         }
-        data_job_id[job_id] = inputs
-        requests.post(
-            url=f"https://webhook.site/{self.webhook_token}",
-            data=json.dumps(data_job_id),
-            headers={"content-type": "application/json"},
-        )
+        # HACK: serializer inputs as a job_id to be able to use them in get_job_result
+        job_id = base64.b64encode(
+            json.dumps(inputs, separators=(",", ":")).encode()
+        ).decode()
 
         return AsyncLaunchJobResponseType(provider_job_id=job_id)
 
@@ -858,7 +858,9 @@ class GoogleVideoApi(VideoInterface):
         self, provider_job_id: str
     ) -> AsyncBaseResponseType:
         api_key = self.api_settings.get("genai_api_key")
-        url = f"https://generativelanguage.googleapis.com/v1beta/files/{provider_job_id}?key={api_key}"
+        inputs = json.loads(base64.b64decode(provider_job_id))
+        process_file_id = inputs["process_file_id"]
+        url = f"https://generativelanguage.googleapis.com/v1beta/files/{process_file_id}?key={api_key}"
         response = requests.get(url=url)
         if response.status_code != 200:
             raise ProviderException(message=response.text, code=response.status_code)
@@ -873,32 +875,11 @@ class GoogleVideoApi(VideoInterface):
                 status="pending", provider_job_id=provider_job_id
             )
         else:
-            wehbook_result, _ = check_webhook_result(
-                provider_job_id, self.webhook_settings
-            )
-            result_object = (
-                next(
-                    filter(
-                        lambda response: provider_job_id in response["content"],
-                        wehbook_result,
-                    ),
-                    None,
-                )
-                if wehbook_result
-                else None
-            )
-            try:
-                content = json.loads(result_object["content"]).get(
-                    provider_job_id, None
-                )
-            except json.JSONDecodeError:
-                raise ProviderException("An error occurred while parsing the response.")
-
             original_response, generated_text = self._request_question_answer(
-                model=content["model"],
+                model=inputs["model"],
                 api_key=api_key,
-                text=content["text"],
-                temperature=content["temperature"],
+                text=inputs["text"],
+                temperature=inputs["temperature"],
                 file_data=file_data,
             )
             create_time = self._is_older_than_3_hours(file_data["createTime"])

--- a/edenai_apis/apis/openai/openai_audio_api.py
+++ b/edenai_apis/apis/openai/openai_audio_api.py
@@ -27,7 +27,7 @@ from .helpers import convert_tts_audio_rate
 
 
 class OpenaiAudioApi(AudioInterface):
-    def audio__speech_to_text_async__launch_job(
+    def audio__speech_to_text(
         self,
         file: str,
         language: str,
@@ -38,7 +38,7 @@ class OpenaiAudioApi(AudioInterface):
         model: Optional[str] = None,
         file_url: str = "",
         provider_params: Optional[dict] = None,
-    ) -> AsyncLaunchJobResponseType:
+    ):
         provider_params = provider_params or {}
         data_job_id = {}
         headers = {
@@ -53,65 +53,10 @@ class OpenaiAudioApi(AudioInterface):
             if response.status_code != 200:
                 raise ProviderException(response.text, response.status_code)
 
-            job_id = str(uuid.uuid4())
         try:
             original_response = response.json()
         except requests.JSONDecodeError as exp:
             raise ProviderException("Internal Server Error", code=500) from exp
-        data_job_id[job_id] = original_response
-        requests.post(
-            url=f"https://webhook.site/{self.webhook_token}",
-            data=json.dumps(data_job_id),
-            headers={"content-type": "application/json"},
-        )
-        return AsyncLaunchJobResponseType(provider_job_id=job_id)
-
-    def audio__speech_to_text_async__get_job_result(
-        self, provider_job_id: str
-    ) -> AsyncBaseResponseType[SpeechToTextAsyncDataClass]:
-        if not provider_job_id:
-            raise ProviderException("Job id None or empty!")
-
-        # Get results from webhooks :
-        # List all webhook results
-        # Getting results from webhook.site
-
-        wehbook_result, response_status = check_webhook_result(
-            provider_job_id, self.webhook_settings
-        )
-
-        if response_status != 200:
-            raise ProviderException(wehbook_result, code=response_status)
-
-        result_object = (
-            next(
-                filter(
-                    lambda response: provider_job_id in response["content"],
-                    wehbook_result,
-                ),
-                None,
-            )
-            if wehbook_result
-            else None
-        )
-
-        if not result_object or not result_object.get("content"):
-            return AsyncPendingResponseType[SpeechToTextAsyncDataClass](
-                provider_job_id=provider_job_id
-            )
-
-        try:
-            original_response = json.loads(result_object["content"]).get(
-                provider_job_id, None
-            )
-        except json.JSONDecodeError:
-            raise ProviderException("An error occurred while parsing the response.")
-
-        if original_response is None:
-            return AsyncPendingResponseType[SpeechToTextAsyncDataClass](
-                provider_job_id=provider_job_id
-            )
-
         diarization = SpeechDiarization(total_speakers=0, entries=[])
         standardized_response = SpeechToTextAsyncDataClass(
             text=original_response.get("text"), diarization=diarization
@@ -119,7 +64,31 @@ class OpenaiAudioApi(AudioInterface):
         return AsyncResponseType[SpeechToTextAsyncDataClass](
             original_response=original_response,
             standardized_response=standardized_response,
-            provider_job_id=provider_job_id,
+            provider_job_id=str(uuid.uuid4()),
+        )
+
+    def audio__speech_to_text_async__launch_job(
+        self,
+        file: str,
+        language: str,
+        speakers: int,
+        profanity_filter: bool,
+        vocabulary: Optional[List[str]],
+        audio_attributes: tuple,
+        model: Optional[str] = None,
+        file_url: str = "",
+        provider_params: Optional[dict] = None,
+    ) -> AsyncLaunchJobResponseType:
+        return self.audio__speech_to_text(
+            file,
+            language,
+            speakers,
+            profanity_filter,
+            vocabulary,
+            audio_attributes,
+            model,
+            file_url,
+            provider_params,
         )
 
     def audio__text_to_speech(


### PR DESCRIPTION
This solution is a bit of a hack and bring some inconsistencies in the async api, but I feel like using webhook.site is even more of a hack, so I chose to do it this way, tell me if you have any suggestions.

### Problem
some subfeatures are async (eg: speech to text async) but we have some providers that don't have any async api for it.
only sync. To make them behave asynchronously we get the response from the provider on launch, and send a request to webhook.site with the response from the provider with a random id.

in the get_results method, from the id we search in webhook.site logs and return the response from the logs. basically using webhook.site as a sort of temporary db.

### Solution
the best would be to separate them into their own sync features (speech_to_text, simply) but in the mean time we can just return the response directly in the launch method, removing the 'get_results' method.