### PR TITLE
Sd2 1080 caching llm prompt

### DIFF
--- a/edenai_apis/apis/anthropic/anthropic_api.py
+++ b/edenai_apis/apis/anthropic/anthropic_api.py
@@ -28,7 +28,10 @@ class AnthropicApi(ProviderInterface, TextInterface, ImageInterface):
         )
         self.llm_client = LLMEngine(
             provider_name=self.provider_name,
-            provider_config={"api_key": self.api_settings.get("api_key")},
+            provider_config={
+                "api_key": self.api_settings.get("api_key"),
+                "cache_control": {"type": "ephemeral"},
+            },
         )
 
     def text__summarize(

--- a/edenai_apis/apis/anthropic/anthropic_api.py
+++ b/edenai_apis/apis/anthropic/anthropic_api.py
@@ -1,22 +1,24 @@
-from typing import Dict, List, Literal, Union, Optional
-from edenai_apis.features import ProviderInterface, TextInterface, ImageInterface
+from typing import Dict, List, Literal, Optional, Union
+
+from edenai_apis.features import ImageInterface, ProviderInterface, TextInterface
 from edenai_apis.features.image.logo_detection.logo_detection_dataclass import (
     LogoDetectionDataClass,
 )
-from edenai_apis.features.text import SummarizeDataClass
-from edenai_apis.features.text.chat.chat_dataclass import (
-    StreamChat,
-    ChatDataClass,
-)
 from edenai_apis.features.multimodal.chat.chat_dataclass import (
     ChatDataClass as ChatMultimodalDataClass,
-    StreamChat as StreamChatMultimodal,
+)
+from edenai_apis.features.multimodal.chat.chat_dataclass import (
     ChatMessageDataClass as ChatMultimodalMessageDataClass,
 )
+from edenai_apis.features.multimodal.chat.chat_dataclass import (
+    StreamChat as StreamChatMultimodal,
+)
+from edenai_apis.features.text import SummarizeDataClass
+from edenai_apis.features.text.chat.chat_dataclass import ChatDataClass, StreamChat
+from edenai_apis.llmengine.llm_engine import LLMEngine
 from edenai_apis.loaders.data_loader import ProviderDataEnum
 from edenai_apis.loaders.loaders import load_provider
 from edenai_apis.utils.types import ResponseType
-from edenai_apis.llmengine.llm_engine import LLMEngine
 
 
 class AnthropicApi(ProviderInterface, TextInterface, ImageInterface):


### PR DESCRIPTION
activate prompt caching for anthropic. Already activate by default for other providers

ref: https://docs.litellm.ai/docs/completion/prompt_caching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an improved caching configuration for more efficient handling of temporary data.
- **Refactor**
	- Streamlined internal code organization to enhance clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->