### PR TITLE
Make that vertexai and gemini translate to google for api keys file

### DIFF
--- a/edenai_apis/llmengine/llm_engine.py
+++ b/edenai_apis/llmengine/llm_engine.py
@@ -731,7 +731,7 @@ class LLMEngine:
 
 class StdLLMEngine(LLMEngine):
 
-    PROVIDER_MAPPING = {"vertex_ai": "google"}
+    PROVIDER_MAPPING = {"vertex_ai": "google", "gemini": "google"}
 
     def __init__(
         self,

--- a/edenai_apis/llmengine/llm_engine.py
+++ b/edenai_apis/llmengine/llm_engine.py
@@ -62,6 +62,7 @@ from edenai_apis.llmengine.prompts import BasePrompt
 from edenai_apis.llmengine.utils.moderation import moderate
 from loaders.data_loader import ProviderDataEnum
 from loaders.loaders import load_provider
+import re
 
 
 class LLMEngine:
@@ -730,6 +731,8 @@ class LLMEngine:
 
 class StdLLMEngine(LLMEngine):
 
+    PROVIDER_MAPPING = {"vertex_ai": "google"}
+
     def __init__(
         self,
         provider_config: dict = {},
@@ -743,6 +746,16 @@ class StdLLMEngine(LLMEngine):
             provider_name=None,
             **kwargs,
         )
+
+    @staticmethod
+    def map_provider(provider_name: str) -> str:
+        if provider_name is None:
+            return None
+        # Try to regex match the keys of PROVIDER_MAPPING and provider_name. The first one ot match wins
+        for key in StdLLMEngine.PROVIDER_MAPPING.keys():
+            if re.match(key, provider_name, re.RegexFlag.IGNORECASE):
+                return StdLLMEngine.PROVIDER_MAPPING[key]
+        return provider_name
 
     def completion(
         self,
@@ -786,7 +799,7 @@ class StdLLMEngine(LLMEngine):
         **kwargs,
     ):
         if "provider" in kwargs:
-            provider_name = kwargs.pop("provider", None)
+            provider_name = StdLLMEngine.map_provider(kwargs.pop("provider", None))
             api_settings = load_provider(
                 ProviderDataEnum.KEY, provider_name, api_keys=api_key
             )

--- a/edenai_apis/llmengine/llm_engine.py
+++ b/edenai_apis/llmengine/llm_engine.py
@@ -799,11 +799,22 @@ class StdLLMEngine(LLMEngine):
         **kwargs,
     ):
         if "provider" in kwargs:
+            import os
             provider_name = StdLLMEngine.map_provider(kwargs.pop("provider", None))
-            api_settings = load_provider(
-                ProviderDataEnum.KEY, provider_name, api_keys=api_key
-            )
-            api_key = api_settings["api_key"]
+            if provider_name == "google":
+                api_settings, location = load_provider(
+                    ProviderDataEnum.KEY,
+                    provider_name=provider_name,
+                    location=True,
+                    api_keys=api_key,
+                )
+                self.project_id = api_settings["project_id"]
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = location
+            else:
+                api_settings = load_provider(
+                    ProviderDataEnum.KEY, provider_name, api_keys=api_key
+                )
+                api_key = api_settings["api_key"]
         try:
             completion_params = {
                 "messages": messages,

--- a/edenai_apis/llmengine/tests/conftest.py
+++ b/edenai_apis/llmengine/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple, Union
 import pytest
 
 from edenai_apis.llmengine.tests.fixtures.mocked_response import (
@@ -139,6 +139,7 @@ def unknown_models_to_litellm() -> List[LiteLLMModel]:
     }
     return test_model
 
+
 @pytest.fixture
 def update_known_models_to_litellm() -> List[LiteLLMModel]:
     test_model = {
@@ -152,6 +153,7 @@ def update_known_models_to_litellm() -> List[LiteLLMModel]:
     }
     return test_model
 
+
 @pytest.fixture
 def invalid_models_to_litellm() -> dict[str, list]:
     return {
@@ -163,3 +165,32 @@ def invalid_models_to_litellm() -> dict[str, list]:
             "mode",
         ]
     }
+
+
+@pytest.fixture
+def mapping_providers() -> List[Tuple[Union[str, None], Union[str, None]]]:
+    return [
+        ("openai", "openai"),
+        ("cohere", "cohere"),
+        ("anthropic", "anthropic"),
+        ("replicate", "replicate"),
+        ("mistral", "mistral"),
+        ("meta", "meta"),
+        ("togetherai", "togetherai"),
+        ("huggingface", "huggingface"),
+        ("azure", "azure"),
+        ("google", "google"),
+        ("vertex_ai-text-models", "google"),
+        ("vertex_ai-chat-models", "google"),
+        ("vertex_ai-language-models", "google"),
+        ("perplexity", "perplexity"),
+        ("openrouter", "openrouter"),
+        ("ai21", "ai21"),
+        ("amazon", "amazon"),
+        ("anyscale", "anyscale"),
+        ("deepinfra", "deepinfra"),
+        ("nlpcloud", "nlpcloud"),
+        ("openllm", "openllm"),
+        ("", ""),
+        (None, None),
+    ]

--- a/edenai_apis/llmengine/tests/conftest.py
+++ b/edenai_apis/llmengine/tests/conftest.py
@@ -179,7 +179,7 @@ def mapping_providers() -> List[Tuple[Union[str, None], Union[str, None]]]:
         ("togetherai", "togetherai"),
         ("huggingface", "huggingface"),
         ("azure", "azure"),
-        ("google", "google"),
+        ("gemini", "google"),
         ("vertex_ai-text-models", "google"),
         ("vertex_ai-chat-models", "google"),
         ("vertex_ai-language-models", "google"),

--- a/edenai_apis/llmengine/tests/test_llm_engine.py
+++ b/edenai_apis/llmengine/tests/test_llm_engine.py
@@ -5,7 +5,7 @@ from edenai_apis.utils.exception import ProviderException
 from edenai_apis.utils.types import ResponseType
 from litellm import register_model
 
-from llmengine.llm_engine import LLMEngine
+from llmengine.llm_engine import LLMEngine, StdLLMEngine
 from llmengine.clients.litellm_client.litellm_client import LiteLLMCompletionClient
 
 
@@ -223,3 +223,8 @@ class TestLLMEngine:
         assert (
             response.original_response["choices"][0]["message"]["content"] is not None
         )
+
+    @pytest.mark.unit
+    def test_map_provider(self, mapping_providers):
+        for source, target in mapping_providers:
+            assert StdLLMEngine.map_provider(source) == target


### PR DESCRIPTION
- **Map providers**
- **Map providers**
- **Add gemini to the mapping**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a standardized mechanism to process and map API provider names, ensuring smoother automatic configuration adjustments.
  
- **Tests**
  - Added unit tests to validate the new provider mapping functionality, enhancing overall integration stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->