### PR TITLE
[fix] escape special chars in ssml

### DIFF
--- a/edenai_apis/utils/ssml.py
+++ b/edenai_apis/utils/ssml.py
@@ -73,11 +73,14 @@ def convert_audio_attr_in_prosody_tag(
     idx_before_last_tag = get_index_before_last_speak_tag(text)
 
     if idx_after_first_tag == -1 or idx_before_last_tag == -1:
+        escaped_text = (
+            text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        )
         return (
             f"<speak{f' {speak_attr}' if speak_attr else ''}>"
             + f"{voice_tag}"
             + (f"<prosody {cleaned_attribs}>" if cleaned_attribs else "")
-            + text
+            + escaped_text
             + (f"</prosody>" if cleaned_attribs else "")
             + f"{f'</voice>' if voice_tag else ''}</speak>"
         )


### PR DESCRIPTION
ref: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-structure#special-characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the handling of special characters in audio text attributes, ensuring that symbols like &, <, and > are correctly rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->