### PR TITLE
Add a reranker to LLM Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pyrightconfig.json
 
 *.env*
 .pre-commit-config.yaml
+local_tests.py

--- a/edenai_apis/llmengine/clients/litellm_client/litellm_client.py
+++ b/edenai_apis/llmengine/clients/litellm_client/litellm_client.py
@@ -835,12 +835,12 @@ class LiteLLMRerankClient(RerankerClient):
             call_params["top_n"] = top_n
         if rank_fields:
             call_params["rank_fields"] = rank_fields
-        if return_documents:
+        if return_documents is not None:
             call_params["return_documents"] = return_documents
         if max_chunks_per_doc:
             call_params["max_chunks_per_doc"] = max_chunks_per_doc
         if max_tokens_per_doc:
-            call_params["max_tokens_per_doct"] = max_tokens_per_doc
+            call_params["max_tokens_per_doc"] = max_tokens_per_doc
 
         try:
             response = await arerank(**call_params, **kwargs)

--- a/edenai_apis/llmengine/clients/reranker.py
+++ b/edenai_apis/llmengine/clients/reranker.py
@@ -1,0 +1,39 @@
+from typing import Any, Coroutine, Dict, List, Literal, Optional, Union
+
+
+from edenai_apis.llmengine.exceptions.llm_engine_exceptions import RerankClientError
+from edenai_apis.llmengine.types.response_types import RerankerResponse
+
+
+class RerankerClient:
+
+    def __init__(
+        self,
+        provider_name: str = None,
+        model_name: Optional[str] = None,
+        provider_config: dict = {},
+    ):
+        self.model_name = model_name
+        self.provider_name = provider_name
+        self.provider_config = provider_config
+        self.model_capabilities = []
+        self.call_params = {}
+
+    async def arerank(
+        self,
+        model: str,
+        query: str,
+        documents: List[Union[str, Dict[str, Any]]],
+        custom_llm_provider: Optional[
+            Literal["cohere", "together_ai", "azure_ai", "infinity", "litellm_proxy"]
+        ] = None,
+        top_n: Optional[int] = None,
+        rank_fields: Optional[List[str]] = None,
+        return_documents: Optional[bool] = True,
+        max_chunks_per_doc: Optional[int] = None,
+        max_tokens_per_doc: Optional[int] = None,
+        **kwargs,
+    ) -> Coroutine[Any, Any, RerankerResponse]:
+        raise RerankClientError(
+            "Not implemented. Please implement this method in a subclass."
+        )

--- a/edenai_apis/llmengine/exceptions/llm_engine_exceptions.py
+++ b/edenai_apis/llmengine/exceptions/llm_engine_exceptions.py
@@ -29,3 +29,13 @@ class CompletionClientError(Exception):
         super().__init__(
             self.message
         )  # TODO polymorph this thing to understand different exceptions and handle them on the logging...
+
+
+class RerankClientError(Exception):
+    def __init__(self, message, input: Optional[dict] = None, status_code: int = 400):
+        self.input = input
+        self.message = message
+        self.status_code = status_code
+        super().__init__(
+            self.message
+        )  # TODO polymorph this thing to understand different exceptions and handle them on the logging...

--- a/edenai_apis/llmengine/types/response_types.py
+++ b/edenai_apis/llmengine/types/response_types.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union
-from litellm import CustomStreamWrapper
+from litellm import CustomStreamWrapper, RerankResponse
 from litellm.types.utils import ModelResponse, EmbeddingResponse, Embedding, Usage
+from litellm.types.rerank import RerankResponseResult, RerankResponseMeta
 
 
 class EmbeddingResponseModel(EmbeddingResponse):
@@ -135,3 +136,15 @@ class CustomStreamWrapperModel(CustomStreamWrapper):
             logging_obj=logging_obj,
             stream_options=stream_options,
         )
+
+
+class RerankerResponse(RerankResponse):
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        results: Optional[
+            List[RerankResponseResult]
+        ] = None,  # Contains index and relevance_score
+        meta: Optional[RerankResponseMeta] = None,
+    ):
+        super().__init__(id=id, results=results, meta=meta)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added document reranking: rank documents by relevance to a query with structured results and metadata.
  - Configurable options: choose number of results, fields to rank, whether to return documents, and chunk/token limits.
  - Multi-provider support: use different reranking providers (including new LiteLLM integration).

- Chores
  - Updated .gitignore to exclude a local test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->